### PR TITLE
Query params ast

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -43,6 +43,7 @@ function literalToSQL(literal) {
     else if (type === 'null') value = 'NULL';
     else if (type === 'star') value = '*';
     else if (['time', 'date', 'timestamp'].includes(type)) value = `${type.toUpperCase()} '${value}'`;
+    else if (type === 'param') value = ':' + value;
 
     return !literal.parentheses ? value : '(' + value + ')';
 }

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -140,7 +140,7 @@ function columnsToSQL(columns) {
             if (column.as !== null) {
                 str += ' AS ';
                 if (column.as.match(/^[a-z_][0-9a-z_]*$/i)) str += identifierToSql(column.as);
-                else str += '\'' + column.as + '\'';
+                else str += '\"' + column.as + '\"';
             }
 
             return str;

--- a/test/ast.spec.js
+++ b/test/ast.spec.js
@@ -224,6 +224,7 @@ describe('AST',() => {
             });
 
             it('should support query param values', () => {
+                
                 sql =  'SELECT * FROM t where t.a > :my_param';
                 expect(getParsedSql(sql)).to.equal('SELECT * FROM "t" WHERE "t"."a" > :my_param');
             });

--- a/test/ast.spec.js
+++ b/test/ast.spec.js
@@ -45,8 +45,8 @@ describe('AST',() => {
             });
 
             it('should escape aliases with non-identifier chars (/a-z0-9_/i)', () => {
-                sql = `SELECT col AS 'foo bar' FROM t`;
-                expect(getParsedSql(sql)).to.contain(`"col" AS 'foo bar'`);
+                sql = `SELECT col AS "foo bar" FROM t`;
+                expect(getParsedSql(sql)).to.contain(`"col" AS "foo bar"`);
             });
 
             ["'", '"', 'n', 't', '\\'].forEach((char) => {

--- a/test/ast.spec.js
+++ b/test/ast.spec.js
@@ -223,6 +223,11 @@ describe('AST',() => {
                 });
             });
 
+            it('should support query param values', () => {
+                sql =  'SELECT * FROM t where t.a > :my_param';
+                expect(getParsedSql(sql)).to.equal('SELECT * FROM "t" WHERE "t"."a" > :my_param');
+            });
+
             it('should support BETWEEN operator', () => {
                 sql = `SELECT a FROM t WHERE id between '1' and 1337`;
                 expect(getParsedSql(sql)).to.equal(`SELECT "a" FROM "t" WHERE "id" BETWEEN '1' AND 1337`);

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -247,6 +247,17 @@ describe('select', () => {
             });
         });
 
+        it('should parse parameters', () => {
+            ast = parser.parse('SELECT * FROM t where t.a > :my_param');
+
+            expect(ast.where).to.eql({
+                type: 'binary_expr',
+                operator: '>',
+                left: { type: 'column_ref', table: 't', column: 'a' },
+                right: { type: 'param', value: 'my_param' }
+            });
+        });
+
         it('should parse multiple conditions', () => {
             ast = parser.parse(`SELECT * FROM t where t.c between 1 and 't' AND Not true`);
 


### PR DESCRIPTION
Query parameters seem to be supported when going from query string => ast, but they don't seem to be supported when going from ast => string. Added the fix and a couple tests around query params. Thanks!