### PR TITLE
Generate correct SQL queries on empty arrays

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -226,10 +226,10 @@ function selectToSQL(stmt) {
     if (Array.isArray(stmt.from)) clauses.push('FROM', tablesToSQL(stmt.from));
 
     if (has(stmt, 'where') && stmt.where !== null) clauses.push('WHERE ' + exprToSQL(stmt.where));
-    if (Array.isArray(stmt.groupby)) clauses.push('GROUP BY', getExprListSQL(stmt.groupby).join(', '));
+    if (Array.isArray(stmt.groupby) && stmt.groupby.length > 0) clauses.push('GROUP BY', getExprListSQL(stmt.groupby).join(', '));
     if (has(stmt, 'having') && stmt.having !== null) clauses.push('HAVING ' + exprToSQL(stmt.having));
 
-    if (Array.isArray(stmt.orderby)) {
+    if (Array.isArray(stmt.orderby) && stmt.orderby.length > 0) {
         const orderExpressions = stmt.orderby.map(expr => exprToSQL(expr.expr) + ' ' + expr.type);
         clauses.push('ORDER BY', orderExpressions.join(', '));
     }

--- a/test/ast.spec.js
+++ b/test/ast.spec.js
@@ -361,6 +361,12 @@ describe('AST', () => {
                 expect(getParsedSql('SELECT a FROM t GROUP BY t.b, t.c'))
                     .to.equal('SELECT "a" FROM "t" GROUP BY "t"."b", "t"."c"');
             });
+
+            it('should not generate an empty GROUP BY clause on empty arrays', () => {
+                const ast = parser.parse('SELECT a FROM t');
+                ast.groupby = [];
+                expect(util.astToSQL(ast)).to.equal('SELECT "a" FROM "t"');
+            });
         });
 
         describe('having clause', () => {
@@ -394,6 +400,12 @@ describe('AST', () => {
             it('should support complex expressions', () => {
                 expect(getParsedSql('SELECT a FROM t ORDER BY rand() ASC'))
                     .to.equal('SELECT "a" FROM "t" ORDER BY rand() ASC');
+            });
+
+            it('should not generate an empty ORDER BY clause on empty arrays', () => {
+                const ast = parser.parse('SELECT a FROM t');
+                ast.orderby = [];
+                expect(util.astToSQL(ast)).to.equal('SELECT "a" FROM "t"');
             });
         });
 


### PR DESCRIPTION
Hey there! First of all, thanks a lot for your library, we've been using it very happily after considering multiple SQL parsers, yours coming out on top :)
I'll try to contribute back to it as much as I can as we use it more and more 😊

The way we use is through AST manipulations: we parse queries, make changes to the AST (through a UI where you can add columns, group by stuff, order stuff, etc.) and generate them back to SQL queries.

For example, we have a bunch of:

```ts
if (this.ast.groupby) {
  this.ast.groupby = this.ast.groupby.filter(({ column }) => column !== 'foo');
}

if (this.ast.groupby.length === 0) {
  this.ast.groupby = null;
}
```

The last 3 lines are required because `filter` can generate an empty array, which `astToSQL` would generate back into `SELECT a FROM t GROUP BY`.

This PR changes that, so that empty arrays in `groupby` and `orderby` fields still generate valid SQL queries. That makes the extra checks unnecessary, and makes consuming code less fragile (e.g. forgetting a null check somewhere).
I haven't touched other fields because I am not using them (yet) and didn't want to change something I haven't actually fully tested, but feel free to tell me which other fields you want me to apply this to.

Thanks! 🙏