### PR TITLE
feat: include concat operator

### DIFF
--- a/sql.pegjs
+++ b/sql.pegjs
@@ -668,7 +668,7 @@ additive_expr
     }
 
 additive_operator
-  = "+" / "-"
+  = "+" / "-" / "||"
 
 multiplicative_expr
   = head:primary


### PR DESCRIPTION
Currently you get an error if you use SQL with concatenation. As far as I'm aware, the || operator is part of ANSI SQL and it seems simple to support.

I  noticed there's a comment

```
/**
 * Borrowed from PL/SQL ,the priority of below list IS ORDER BY DESC
 * ---------------------------------------------------------------------------------------------------
 * | +, -                                                     | identity, negation                   |
 * | *, /                                                     | multiplication, division             |
 * | +, -                                                     | addition, subtraction, concatenation |
 * | =, <, >, <=, >=, <>, !=, IS, LIKE, BETWEEN, IN           | comparion                            |
 * | !, NOT                                                   | logical negation                     |
 * | AND                                                      | conjunction                          |
 * | OR                                                       | inclusion                            |
 * ---------------------------------------------------------------------------------------------------
 */
```

Which seems to suggest concatenation should be grouped in with addition and subtraction, so that's what I did.  